### PR TITLE
Fix wise guys lookup.

### DIFF
--- a/client/src/components/Villain.jsx
+++ b/client/src/components/Villain.jsx
@@ -7,7 +7,7 @@ import {getInfoIfNeeded} from '../actions';
 // Pure component: fully driven by props
 export const Villain = React.createClass({
   mixins: [PureRenderMixin],
-  componentDidMount: function() { 
+  componentDidMount: function() {
       return this.props.componentDidMount(this.props.id);
   },
   render: function() {
@@ -23,7 +23,7 @@ export const Villain = React.createClass({
         <p>None. {name} is an underdog.</p>
       }
       {fetched && wiseGuys.length !== 0 &&
-        <p>A few wiseguys: {wiseGuys}.</p>
+        <p>Wiseguys count: {wiseGuys.length}.</p>
       }
       <p>Last updated at {lastUpdated}.</p>
     </div>;
@@ -48,7 +48,7 @@ function mapStateToProps(state, ownProps) {
 function mapDispatchToProps(dispatch) {
     return {
         componentDidMount: function(id) {
-            dispatch(getInfoIfNeeded(id));            
+            dispatch(getInfoIfNeeded(parseInt(id)));
         }
     }
 }


### PR DESCRIPTION
Yo!

I took a stab at figuring out what was going on here. This had me pretty stumped.. you could clearly see the nested `villains` object in the call to `JSON.stringify`, but it didn't seem to be returning. :confused: 

I eventually figured it out. It looks like your immutable `villains` state was sometimes being set with an id that was an integer and at other times one that was a string. For instance, the id from `react-router` is a string but the one from the API is an integer. The result being a map that contains villain dups of varying freshness.

Opening a quick PR that should unblock you on that issue.